### PR TITLE
Fix GPG signing in CI and remove draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: "~> v2"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,6 @@ release:
   extra_files:
     - glob: terraform-registry-manifest.json
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
-  draft: true
 
 changelog:
   sort: asc


### PR DESCRIPTION
Add --pinentry-mode loopback to GPG args to prevent interactive passphrase prompt in CI. Remove draft:true so Terraform Registry can discover the release.

