### PR TITLE
Include manifest in SHA256SUMS checksum

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,9 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
+  extra_files:
+    - glob: terraform-registry-manifest.json
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
 
 signs:
   - artifacts: checksum


### PR DESCRIPTION
The Terraform Registry requires that the manifest file be included in the SHA256SUMS checksum file. Without it, release ingestion fails silently. This was the cause of v0.8.0 not appearing on the registry, according to https://github.com/hashicorp/terraform-registry-support/issues/28#issuecomment-4872157569


